### PR TITLE
added JSdoc coverage for sequelize models

### DIFF
--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,32 +1,22 @@
 /* eslint-disable global-require */
 /* eslint-disable security/detect-non-literal-require */
 /* eslint-disable import/no-dynamic-require */
-const fs = require('fs');
-const path = require('path');
 const Sequelize = require('sequelize');
 const { db } = require('../config/config');
 
-const basename = path.basename(__filename);
-
 const sequelize = new Sequelize(db.database, db.username, db.password, db);
-const models = {};
 
-// eslint-disable-next-line security/detect-non-literal-fs-filename
-fs.readdirSync(__dirname)
-  .filter((file) => {
-    return file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js';
-  })
-  .forEach((file) => {
-    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
-    models[model.name] = model;
-  });
+const models = {
+  sequelize,
+  Sequelize,
+  User: require('./user')(sequelize, Sequelize.DataTypes),
+  token: require('./token')(sequelize, Sequelize.DataTypes),
+};
+
 Object.keys(models).forEach((modelName) => {
   if (models[modelName].associate) {
     models[modelName].associate(models);
   }
 });
-
-models.sequelize = sequelize;
-models.Sequelize = Sequelize;
 
 module.exports = models;

--- a/src/models/token.js
+++ b/src/models/token.js
@@ -1,6 +1,15 @@
 const { Model } = require('sequelize');
 const { tokenTypes } = require('../config/tokens');
 
+/**
+ * @typedef {import('sequelize').Sequelize} Sequelize
+ * @typedef {import('sequelize/types')} DataTypes
+ */
+
+/**
+ * @param {DataTypes} DataTypes
+ * @param {Sequelize} sequelize
+ */
 module.exports = (sequelize, DataTypes) => {
   class token extends Model {
     /**

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -3,6 +3,16 @@ const { Model } = require('sequelize');
 const bcrypt = require('bcryptjs');
 const { roles } = require('../config/roles');
 
+/**
+ * @typedef {import('sequelize').Sequelize} Sequelize
+ * @typedef {import('sequelize/types')} DataTypes
+ */
+
+/**
+ * @param {DataTypes} DataTypes
+ * @param {Sequelize} sequelize
+ */
+
 module.exports = (sequelize, DataTypes) => {
   class User extends Model {
     /**


### PR DESCRIPTION
with this commit, we can now have Jsdoc suggestions for the models. while creating a new model make sure to add the Jsdoc type definitions and add the model imports in the index.js of the models directory.