### PR TITLE
Update config.js

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -47,7 +47,7 @@ module.exports = {
     host: envVars.DB_HOST,
     dialect: envVars.DB_DIALECT,
     port: envVars.DB_PORT,
-    operatorsAliases: false,
+    operatorsAliases: 0,
   },
   jwt: {
     secret: envVars.JWT_SECRET,


### PR DESCRIPTION
Sequelize requires it to be an int instead of a boolean now.

`
[SEQUELIZE0004] DeprecationWarning: A boolean value was passed to options.operatorsAliases. This is a no-op with v5 and should be removed.`